### PR TITLE
added JawsDB config, deployed to Heroku

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -14,10 +14,7 @@
     "dialect": "mysql"
   },
   "production": {
-    "username": "root",
-    "password": null,
-    "database": "database_production",
-    "host": "127.0.0.1",
+    "use_env_variable": "JAWSDB_URL",
     "dialect": "mysql"
   }
 }


### PR DESCRIPTION
Deployed app to Heroku, updated Heroku app to use JawsDB for persistent data.  Test environment still uses local DBs.